### PR TITLE
对朋友圈cell高度进行缓存---防止过多的没必要的重复计算,节约性能

### DIFF
--- a/LZEasemob3/Classes/ViewModel/LZMomentsViewModel.h
+++ b/LZEasemob3/Classes/ViewModel/LZMomentsViewModel.h
@@ -49,7 +49,10 @@
 @property (nonatomic, assign, readonly) CGRect commentBgViewF;
 @property (nonatomic, assign, readonly) CGRect dividerF;
 
-@property (nonatomic, assign, readonly) CGFloat cellHeight;
+/* 此次cell最新高度 */
+@property (nonatomic, assign) CGFloat cellHeight;
+/* 上一次高度 */
+@property (nonatomic, assign) CGFloat lastCellHeight;
 
 - (CGSize)getCommentViewSize;
 

--- a/LZEasemob3/Classes/ViewModel/LZMomentsViewModel.m
+++ b/LZEasemob3/Classes/ViewModel/LZMomentsViewModel.m
@@ -73,6 +73,10 @@ extern CGFloat maxContentLabelHeight;
         _isOpening = NO;
     } else {
         _isOpening = isOpening;
+        
+        // 清除当前cell缓存的高度 (只有点击"全文"、"收起"按钮的情况下, 才有必要对当前cell的高度进行重新计算-----否则没必要)
+        // cell高度清理  重新计算高度
+        _cellHeight = 0;
     }
 }
 
@@ -85,84 +89,93 @@ extern CGFloat maxContentLabelHeight;
 
 - (CGFloat)cellHeight
 {
-    CGFloat margin = 10;
-    CGFloat cellW = [UIScreen mainScreen].bounds.size.width;
-    CGFloat cellHeight;
-    CGFloat commentViewWidth = cellW - 70;
-    
-    CGFloat iconViewX = margin;
-    CGFloat iconViewY = margin;
-    CGFloat iconViewWH = 45;
-    _iconViewF = CGRectMake(iconViewX, iconViewY, iconViewWH, iconViewWH);
-    
-    
-    CGFloat nameLableX = CGRectGetMaxX(_iconViewF) + margin;
-    CGFloat nameLableY = margin;
-    
-    
-    _nameLableF = CGRectMake(nameLableX, nameLableY, commentViewWidth, 20);
-    
-    if (self.msgContent.length) {  // 有文字
-        CGFloat contentLabelX = nameLableX;
-        CGFloat contentLabelY = CGRectGetMaxY(_nameLableF) + margin * 0.5;
-        CGSize msgContentSize = [self.msgContent sizeWithFont:[UIFont systemFontOfSize:15] maxW:commentViewWidth];
-        if (self.shouldShowMoreButton) { // 如果文字高度超过60
-
-            if (self.isOpening) { // 如果需要展开
-                _contentLabelF = CGRectMake(contentLabelX, contentLabelY, msgContentSize.width, 60);
-            } else {
-                _contentLabelF = CGRectMake(contentLabelX, contentLabelY, msgContentSize.width, msgContentSize.height);
-            }
-            _moreButtonF = CGRectMake(nameLableX, CGRectGetMaxY(_contentLabelF) + margin * 0.2, 30, 15);
-            
-            cellHeight = CGRectGetMaxY(_moreButtonF) + margin * 0.5;
-        }else {  // 没有超过60
-            _contentLabelF = CGRectMake(contentLabelX, contentLabelY, msgContentSize.width, msgContentSize.height);
-            cellHeight = CGRectGetMaxY(_contentLabelF) + margin * 0.5;
-        }
-    }else {
-        cellHeight = CGRectGetMaxY(_nameLableF) + margin * 0.5;
-    }
-    
-    // 有图
-    NSInteger count = self.picNamesArray.count;
-    if (count) {
-        CGFloat itemWH = (([UIScreen mainScreen].bounds.size.width - 70) - (kPicViewColCount - 1) * (kPicViewItemMargin + kStatusCellMargin)) / kPicViewColCount;
-
-        NSInteger col = count == 4 ? 2 : (count >= kPicViewColCount ? kPicViewColCount : count);
-        NSInteger row = (count - 1) / kPicViewColCount + 1;
-        CGFloat width = ceil(col * itemWH + (col - 1) * kPicViewItemMargin);
-        CGFloat height = ceil(row * itemWH + (row - 1) * kPicViewItemMargin);
+    // 模仿苹果'懒加载'的思想 加上判断 
+    //(只有在cell高度为空-即第一次展示时/ 或者点击了"全文"、"收起"按钮后cell高度需要重新计算,因此将cell高度被人为置为0, 
+    // 当前需要展示的cell高度和上一次的高度 不同)    才需要重新计算cell高度
+    // 否则  不需要重新计算 ---  能极大减少运算次数, 提高性能
+    if (!_cellHeight || _cellHeight==0 || _cellHeight!=_lastCellHeight) {
+        CGFloat margin = 10;
+        CGFloat cellW = [UIScreen mainScreen].bounds.size.width;
+        CGFloat commentViewWidth = cellW - 70;
         
-        _photoContainerViewF = CGRectMake(nameLableX, cellHeight, width, height);
-        cellHeight = CGRectGetMaxY(_photoContainerViewF) + margin * 0.5;
-    }
-    
-    _originalViewF = CGRectMake(0, 0, cellW, cellHeight);
-    
-    CGSize timeLabelSize = [self.time sizeWithFont:[UIFont systemFontOfSize:13] maxW:cellW - nameLableX - margin];
-    CGFloat timeLabelY = CGRectGetMaxY(_originalViewF) + margin * 0.5;
-    _timeLabelF = CGRectMake(nameLableX, timeLabelY, timeLabelSize.width, timeLabelSize.height);
-    
-    
-    CGFloat operationButtonWH = 25;
-    CGFloat operationButtonX = cellW - operationButtonWH - margin;
-    CGFloat operationButtonY = timeLabelY - margin * 0.5;
-    _operationButtonF = CGRectMake(operationButtonX, operationButtonY, operationButtonWH, operationButtonWH);
-    
+        CGFloat iconViewX = margin;
+        CGFloat iconViewY = margin;
+        CGFloat iconViewWH = 45;
+        _iconViewF = CGRectMake(iconViewX, iconViewY, iconViewWH, iconViewWH);
+        
+        
+        CGFloat nameLableX = CGRectGetMaxX(_iconViewF) + margin;
+        CGFloat nameLableY = margin;
+        
+        
+        _nameLableF = CGRectMake(nameLableX, nameLableY, commentViewWidth, 20);
+        
+        if (self.msgContent.length) {  // 有文字
+            CGFloat contentLabelX = nameLableX;
+            CGFloat contentLabelY = CGRectGetMaxY(_nameLableF) + margin * 0.5;
+            CGSize msgContentSize = [self.msgContent sizeWithFont:[UIFont systemFontOfSize:15] maxW:commentViewWidth];
+            if (self.shouldShowMoreButton) { // 如果文字高度超过60
 
-    if (!self.status.commentItemsArray.count && !self.status.likeItemsArray.count) {
-        cellHeight = CGRectGetMaxY(_timeLabelF) + margin * 0.5;
-    }else {
-        CGSize commentViewSize = [self getCommentViewSize];
-        _commentBgViewF = CGRectMake(nameLableX, cellHeight, commentViewSize.width, commentViewSize.height);
-        cellHeight = CGRectGetMaxY(_commentBgViewF) + margin * 0.5;
+                if (self.isOpening) { // 如果需要展开
+                    _contentLabelF = CGRectMake(contentLabelX, contentLabelY, msgContentSize.width, 60);
+                } else {
+                    _contentLabelF = CGRectMake(contentLabelX, contentLabelY, msgContentSize.width, msgContentSize.height);  // 60+ 本身
+                }
+                _moreButtonF = CGRectMake(nameLableX, CGRectGetMaxY(_contentLabelF) + margin * 0.2, 30, 15);
+                
+                _cellHeight = CGRectGetMaxY(_moreButtonF) + margin * 0.5;
+            }else {  // 没有超过60
+                _contentLabelF = CGRectMake(contentLabelX, contentLabelY, msgContentSize.width, msgContentSize.height);
+                _cellHeight = CGRectGetMaxY(_contentLabelF) + margin * 0.5;
+            }
+        }else {
+            _cellHeight = CGRectGetMaxY(_nameLableF) + margin * 0.5;
+        }
+        
+        // 有图
+        NSInteger count = self.picNamesArray.count;
+        if (count) {
+            CGFloat itemWH = (([UIScreen mainScreen].bounds.size.width - 70) - (kPicViewColCount - 1) * (kPicViewItemMargin + kStatusCellMargin)) / kPicViewColCount;
+
+            NSInteger col = count == 4 ? 2 : (count >= kPicViewColCount ? kPicViewColCount : count);
+            NSInteger row = (count - 1) / kPicViewColCount + 1;
+            CGFloat width = ceil(col * itemWH + (col - 1) * kPicViewItemMargin);
+            CGFloat height = ceil(row * itemWH + (row - 1) * kPicViewItemMargin);
+            
+            _photoContainerViewF = CGRectMake(nameLableX, _cellHeight, width, height);
+            _cellHeight = CGRectGetMaxY(_photoContainerViewF) + margin * 0.5;
+        }
+        
+        _originalViewF = CGRectMake(0, 0, cellW, _cellHeight);
+        
+        CGSize timeLabelSize = [self.time sizeWithFont:[UIFont systemFontOfSize:13] maxW:cellW - nameLableX - margin];
+        CGFloat timeLabelY = CGRectGetMaxY(_originalViewF) + margin * 0.5;
+        _timeLabelF = CGRectMake(nameLableX, timeLabelY, timeLabelSize.width, timeLabelSize.height);
+        
+        
+        CGFloat operationButtonWH = 25;
+        CGFloat operationButtonX = cellW - operationButtonWH - margin;
+        CGFloat operationButtonY = timeLabelY - margin * 0.5;
+        _operationButtonF = CGRectMake(operationButtonX, operationButtonY, operationButtonWH, operationButtonWH);
+        
+
+        if (!self.status.commentItemsArray.count && !self.status.likeItemsArray.count) {
+            _cellHeight = CGRectGetMaxY(_timeLabelF) + margin * 0.5;
+        }else {
+            CGSize commentViewSize = [self getCommentViewSize];
+            _commentBgViewF = CGRectMake(nameLableX, _cellHeight, commentViewSize.width, commentViewSize.height);
+            _cellHeight = CGRectGetMaxY(_commentBgViewF) + margin * 0.5;
+        }
+        _dividerF = CGRectMake(0, _cellHeight, cellW, 1);
+        
+        _cellHeight = CGRectGetMaxY(_dividerF) + margin;
+        
+        
+        // 最后---缓存上一次cell高度
+        _lastCellHeight = _cellHeight;
+        
     }
-    _dividerF = CGRectMake(0, cellHeight, cellW, 1);
-    
-    cellHeight = CGRectGetMaxY(_dividerF) + margin;
-    
-    return cellHeight;
+    return _cellHeight;
     
 }
 


### PR DESCRIPTION
对朋友圈模块cell高度进行缓存---防止过多的没必要的重复计算,节约性能
只有点击 "全文" "收起" 按钮  才有必要对该cell高度进行修改   其余的不需要重新计算,  来回拖到展示也不需要---隐藏有必要对cell高度进行缓存(模仿懒加载思想)